### PR TITLE
select fastest mx-repo fixed

### DIFF
--- a/mxrepomanager.cpp
+++ b/mxrepomanager.cpp
@@ -281,7 +281,6 @@ void mxrepomanager::extractUrls(const QStringList &repos)
 {
     foreach(QString line, repos) {
         QStringList linelist = line.split("-");
-        //fehlix
         linelist.removeAt(0);
         listMXurls += linelist.join("-").trimmed() + " ";
     }
@@ -591,7 +590,6 @@ void mxrepomanager::on_pushFastestDebian_clicked()
 void mxrepomanager::on_pushFastestMX_clicked()
 {
     progress->show();
-    // fehlix
     Output out = runCmd("set -o pipefail; netselect -D -I " + listMXurls + "| tr -s ' ' | sed 's/^ //' | cut -d' ' -f2");
     progress->hide();
     if (out.exit_code == 0 && out.str !="") {

--- a/mxrepomanager.cpp
+++ b/mxrepomanager.cpp
@@ -281,7 +281,9 @@ void mxrepomanager::extractUrls(const QStringList &repos)
 {
     foreach(QString line, repos) {
         QStringList linelist = line.split("-");
-        listMXurls += linelist[1].trimmed() + " ";
+        //fehlix
+        linelist.removeAt(0);
+        listMXurls += linelist.join("-").trimmed() + " ";
     }
 }
 
@@ -589,7 +591,8 @@ void mxrepomanager::on_pushFastestDebian_clicked()
 void mxrepomanager::on_pushFastestMX_clicked()
 {
     progress->show();
-    Output out = runCmd("set -o pipefail; netselect -D -I " + listMXurls + "| cut -d' ' -f4");
+    // fehlix
+    Output out = runCmd("set -o pipefail; netselect -D -I " + listMXurls + "| tr -s ' ' | sed 's/^ //' | cut -d' ' -f2");
     progress->hide();
     if (out.exit_code == 0 && out.str !="") {
         selectRepo(out.str);


### PR DESCRIPTION
1st issue: Some newer mx-repo mirrors do have a hyphens '-' within the url, which breaks simple split of repo.txt by hyphen. (fixed)
2nd issue: Netselect output does have in front of speed-numbers spaces within text output. The number of spaces depends on the number of digits of the speed-number. Fixed usage of cut by spaces.