### PR TITLE
Prompt to enable AHS if needed ...

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+mx-repo-manager (24.10.02) mx; urgency=medium
+
+  * Prompt to enable AHS only if it hasn't been recognized and no MX repository is active.
+  * Remove line feed when identifying the machine's hardware name (uname -m).
+  * Customize regex for repository replacement to handle double slashes and eliminate extra spaces.
+
+ -- fehlix <fehlix@mxlinux.org>  Sat, 19 Oct 2024 16:38:02 -0400
+
 mx-repo-manager (24.10.01) mx; urgency=medium
 
   * Revert previous chang


### PR DESCRIPTION
and some more:
  * Prompt to enable AHS only if it hasn't been recognized and no MX repository is active.
  * Remove line feed when identifying the machine's hardware name (uname -m).
  * Customize regex for repository replacement to handle double slashes and eliminate extra spaces.
Note:
- the extra linefeed made it to never prompt/ask for AHS
- Only if user removed mx.list (or commented out all) we need to ask, b/c if a mx-repo is still found, not need to ask for AHS b/c we can detect 
- double slashes and spaced might still there, b/c of wrong localize-repo (now fixed) or user simple manually added wrongly
- last not least ... fairly good tested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a prompt to enable Advanced Hardware Support (AHS) when not recognized and no active MX repository is present.
	- Implemented line feed removal during hardware name identification.

- **Improvements**
	- Enhanced repository replacement process with improved regex handling for double slashes and unnecessary spaces.
	- Updated logic for restoring sources to consider system architecture and existing AHS repository status.

- **Bug Fixes**
	- Fixed issues related to repository substitutions and handling of the `repos.txt` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->