### PR TITLE
Fix ownership and permissions for restored repositories.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mx-repo-manager (24.10.03) mx; urgency=medium
+
+  * Fix ownership and permissions for restored repositories.
+
+ -- fehlix <fehlix@mxlinux.org>  Sat, 19 Oct 2024 18:25:44 -0400
+
 mx-repo-manager (24.10.02) mx; urgency=medium
 
   * Prompt to enable AHS only if it hasn't been recognized and no MX repository is active.

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -804,7 +804,7 @@ void MainWindow::pushRestoreSources_clicked()
     }
 
     // Move the sources list files from the temporary directory to /etc/apt/sources.list.d/
-    cmd = QString("mv -b %1/mx-sources-mx%2/*.list /etc/apt/sources.list.d/")
+    cmd = QString("mv -b %1/mx-sources-mx%2/*.list /etc/apt/sources.list.d/ && chown 0:0 /etc/apt/sources.list.d/* && chmod 644 /etc/apt/sources.list.d/*")
               .arg(tmpdir.path(), QString::number(mx_version));
     shell->runAsRoot(cmd);
 


### PR DESCRIPTION
This was needed:
* Fix ownership and permissions for restored repositories.
in order to avoid repo sources are owned and writable by the user.
So rather an important fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved management of APT repositories with enhanced file ownership and permissions for source list files.
	- Added user feedback for operations related to restoring sources.

- **Bug Fixes**
	- Fixed ownership and permissions for restored repositories to ensure proper access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->